### PR TITLE
Remove explicit dynamodb2 dependency from syncsettings.py

### DIFF
--- a/syncsettings.py
+++ b/syncsettings.py
@@ -3,9 +3,8 @@ from flask import Flask, json, jsonify, abort, request, send_from_directory, _ap
 from userlib import generator
 import merger.bulkmerge as bulkmerge
 import merger.unitmerge as unitmerge
-from database.dbconn import get_db
+from database.dbconn import get_db, ItemNotFound
 from userlib.reciever import validate_prefs, validate_work
-from boto.dynamodb2.exceptions import ItemNotFound
 
 import traceback
 import sys


### PR DESCRIPTION
Replaced with an explicit dependency on the database abstraction layer.

In this instance it just happens to be the dynamodb2 implementation.
